### PR TITLE
Update sp800_22_overlapping_template_matching_test.py

### DIFF
--- a/sp800_22_overlapping_template_matching_test.py
+++ b/sp800_22_overlapping_template_matching_test.py
@@ -48,9 +48,9 @@ def overlapping_template_matching_test(bits,blen=6):
     
     N = 968
     K = 5
-    M = 1062
+    M = 1032
     if len(bits) < (M*N):
-        print("Insufficient data. %d bit provided. 1,028,016 bits required" % len(bits))
+        print("Insufficient data. %d bit provided. 998,976 bits required" % len(bits))
         return False, 0.0, None
     
     blocks = list() # Split into N blocks of M bits


### PR DESCRIPTION
M has been set to 1032 in the test code.
1,028,016 = 1062 × 968， 998976 = 1032 × 968.

Please see Page 2-17 in NIST SP 800-22 Revision.1a 'A Statistical Test Suite for Random and Pseudorandom Number Generators for Cryptographic Applications'. The link is: https://csrc.nist.gov/publications/detail/sp/800-22/rev-1a/final