### PR TITLE
update sp800_22_non_overlapping_template_matching_test.py

### DIFF
--- a/sp800_22_non_overlapping_template_matching_test.py
+++ b/sp800_22_non_overlapping_template_matching_test.py
@@ -105,9 +105,9 @@ def non_overlapping_template_matching_test(bits):
 
     chisq = 0.0  # Compute Chi-Square
     for j in range(N):
-        chisq += ((W[j] - mu)**2)/(sigma**2)
+        chisq += ((W[j] - mu)**2)/(sigma)
 
-    p = gammaincc(N/2.0, chisq/2.0) # Compute P value
+    p = gammaincc((N-1)/2.0, chisq/2.0) # Compute P value
 
     success = ( p >= 0.01)
     return (success,p,None)


### PR DESCRIPTION
When using the sp800_22_non_overlapping_template_matching_test.py, I observed that the calculated p-value occasionally exceeded 1. After investigation, this anomaly was traced to an implementation error in the chi-square statistic calculation within the code